### PR TITLE
Allow configuration of a custom LrcLib server

### DIFF
--- a/Jellyfin.Plugin.LrcLib/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.LrcLib/Configuration/PluginConfiguration.cs
@@ -8,6 +8,11 @@ namespace Jellyfin.Plugin.LrcLib.Configuration;
 public class PluginConfiguration : BasePluginConfiguration
 {
     /// <summary>
+    /// The default base URL for accessing the API.
+    /// </summary>
+    public const string DefaultBaseUrl = "https://lrclib.net";
+
+    /// <summary>
     /// Gets or sets a value indicating whether to use strict search.
     /// </summary>
     public bool UseStrictSearch { get; set; } = true;
@@ -21,4 +26,9 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether to exclude album name.
     /// </summary>
     public bool ExcludeAlbumName { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the base URL used for accessing the API.
+    /// </summary>
+    public string BaseUrl { get; set; } = DefaultBaseUrl;
 }

--- a/Jellyfin.Plugin.LrcLib/Configuration/config.html
+++ b/Jellyfin.Plugin.LrcLib/Configuration/config.html
@@ -24,6 +24,14 @@
                             <input is="emby-checkbox" type="checkbox" id="excludeAlbumName" />
                             <span>Exclude album name from the search parameters.</span>
                         </label>
+                        <div class="inputContainer" id="baseUrlContainer">
+                            <label class="inputLabel" for="baseUrl">Base URL used for accessing the API.</label>
+                            <input is="emby-input" id="baseUrl" class="emby-input" required="required"></input>
+                            <div class="fieldDescription">
+                                This option allows usage of a custom LrcLib server, set to the value
+                                https://lrclib.net to use the default server.
+                            </div>
+                        </div>
                         <br />
                         <div>
                             <button is="emby-button" type="submit" data-theme="b" class="raised button-submit block">
@@ -51,6 +59,7 @@
 
                     document.querySelector('#excludeArtistName').checked = config.ExcludeArtistName;
                     document.querySelector('#excludeAlbumName').checked = config.ExcludeAlbumName;
+                    document.querySelector('#baseUrl').value = config.BaseUrl || 'https://lrclib.net';
                     Dashboard.hideLoadingMsg();
                 });
             },
@@ -62,6 +71,7 @@
                     config.UseStrictSearch = document.querySelector('#useStrictSearch').checked;
                     config.ExcludeArtistName = document.querySelector('#excludeArtistName').checked;
                     config.ExcludeAlbumName = document.querySelector('#excludeAlbumName').checked;
+                    config.BaseUrl = document.querySelector('#baseUrl').value;
 
                     ApiClient.updatePluginConfiguration(LrcLibPluginConfiguration.uniquePluginId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin.Plugin.LrcLib/LrcLibProvider.cs
+++ b/Jellyfin.Plugin.LrcLib/LrcLibProvider.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using Jellyfin.Plugin.LrcLib.Configuration;
 using Jellyfin.Plugin.LrcLib.Models;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Common.Net;
@@ -24,7 +25,6 @@ namespace Jellyfin.Plugin.LrcLib;
 /// </summary>
 public class LrcLibProvider : ILyricProvider
 {
-    private const string BaseUrl = "https://lrclib.net";
     private const string SyncedSuffix = "synced";
     private const string PlainSuffix = "plain";
     private const string SyncedFormat = "lrc";
@@ -43,6 +43,8 @@ public class LrcLibProvider : ILyricProvider
         _httpClientFactory = httpClientFactory;
         _logger = logger;
     }
+
+    private static string BaseUrl => LrcLibPlugin.Instance?.Configuration.BaseUrl ?? PluginConfiguration.DefaultBaseUrl;
 
     private static bool UseStrictSearch => LrcLibPlugin.Instance?.Configuration.UseStrictSearch ?? true;
 


### PR DESCRIPTION
The BaseUrl can now be specified in the settings page of the plugin (fixing #28).

Tested locally and able to access both a local server and remote (default). The default still fails to find any lyrics but is behaving the same (see #38). For the local server with no restriction on user agent the lyrics are found both via the scheduled task and updating an individual songs lyrics.